### PR TITLE
Add comma to make migration command

### DIFF
--- a/bin/cli/src/commands/make_migration.rs
+++ b/bin/cli/src/commands/make_migration.rs
@@ -45,7 +45,7 @@ pub fn make(package: Option<&String>, name: &str) {
 
     module = module.replace(
         "register_migration![",
-        format!("register_migration![\n{}::{}", module_name, struct_name).as_str(),
+        format!("register_migration![\n{}::{},", module_name, struct_name).as_str(),
     );
 
     _ = std::fs::write(&mod_path, format!("mod {}; \n{}", &module_name, module));


### PR DESCRIPTION
Added a comma to the make command. This may be incomplete. You may want to add a check for whether there are multiple migrations before adding a comma. I did, however, test this and it works regardless of a trailing comma.